### PR TITLE
Some RFC 1769 conformance

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -31,6 +31,7 @@
 #define OFFSET_MINUTES_CONFIG_ID "offsetMinutes"
 // Seconds between 1900 (NTP epoch) and 2000 (Wii U epoch)
 #define NTP_TIMESTAMP_DELTA 3155673600llu
+#define LI_UNSYNC 0xc0
 
 // Important plugin information.
 WUPS_PLUGIN_NAME("Wii U Time Sync");
@@ -148,6 +149,11 @@ OSTime NTPGetTime(const char* hostname)
 
     // Close the socket
     close(sockfd);
+
+    // Basic validity check:
+    if ((packet.li_vn_mode & LI_UNSYNC) == LI_UNSYNC || packet.stratum == 0 || !(packet.txTm_s | packet.txTm_f)) {
+        return 0;
+    }
 
     // These two fields contain the time-stamp seconds as the packet left the NTP server.
     // The number of seconds correspond to the seconds passed since 1900.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -32,6 +32,9 @@
 // Seconds between 1900 (NTP epoch) and 2000 (Wii U epoch)
 #define NTP_TIMESTAMP_DELTA 3155673600llu
 #define LI_UNSYNC 0xc0
+#define MODE_MASK 0x7
+#define MODE_CLIENT 0x3
+#define MODE_SERVER 0x4
 
 // Important plugin information.
 WUPS_PLUGIN_NAME("Wii U Time Sync");
@@ -104,7 +107,7 @@ OSTime NTPGetTime(const char* hostname)
     memset(&packet, 0, sizeof(packet));
 
     // Set the first byte's bits to 00,001,011 for li = 0, vn = 1, and mode = 3. The rest will be left set to zero.
-    packet.li_vn_mode = 0x0b;
+    packet.li_vn_mode = (1 << 3) | MODE_CLIENT;
 
     // Create a socket
     int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
@@ -151,7 +154,7 @@ OSTime NTPGetTime(const char* hostname)
     close(sockfd);
 
     // Basic validity check:
-    if ((packet.li_vn_mode & LI_UNSYNC) == LI_UNSYNC || packet.stratum == 0 || !(packet.txTm_s | packet.txTm_f)) {
+    if ((packet.li_vn_mode & LI_UNSYNC) == LI_UNSYNC || (packet.li_vn_mode & MODE_MASK) != MODE_SERVER || packet.stratum == 0 || !(packet.txTm_s | packet.txTm_f)) {
         return 0;
     }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -102,8 +102,8 @@ OSTime NTPGetTime(const char* hostname)
     ntp_packet packet;
     memset(&packet, 0, sizeof(packet));
 
-    // Set the first byte's bits to 00,011,011 for li = 0, vn = 3, and mode = 3. The rest will be left set to zero.
-    packet.li_vn_mode = 0x1b;
+    // Set the first byte's bits to 00,001,011 for li = 0, vn = 1, and mode = 3. The rest will be left set to zero.
+    packet.li_vn_mode = 0x0b;
 
     // Create a socket
     int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);


### PR DESCRIPTION
This changes the protocol version to 1 for maximum compatibility, see:
>   The VN field must
>   agree with the software version of the NTP or SNTP server; however,
>   NTP Version 3 (RFC-1305) servers will also accept Version 2 (RFC-
>   1119) and Version 1 (RFC-1059) messages, while NTP Version 2 servers
>   will also accept NTP Version 1 messages. Version 0 (RFC-959) messages
>   are no longer supported. Since there are NTP servers of all three
>   versions interoperating in the Internet of today, it is recommended
>   that the VN field be set to 1.

It also adds the validity checks for the server reply as described at page 9 and 10 of the same RFC.

https://www.rfc-editor.org/rfc/rfc1769.html