### PR TITLE
More refactoring, and better Preview function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ dkms.conf
 *.lst
 *.rpx
 *.wps
+*.json
+*.zip
+compile_flags.txt
+
+# Temporary files
+*~

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,13 @@ INCLUDES	:=	source
 #-------------------------------------------------------------------------------
 # options for code generation
 #-------------------------------------------------------------------------------
-CFLAGS	:=	-Wall -Wextra -Wundef -Wshadow -Wpointer-arith -Wcast-align \
+CFLAGS	:=	-Wall -Wextra -Wundef -Wpointer-arith -Wcast-align \
 			-O2 -fipa-pta -pipe -ffunction-sections \
 			$(MACHDEP)
 
 CFLAGS	+=	$(INCLUDE) -D__WIIU__ -D__WUT__ -D__WUPS__ 
 
-CXXFLAGS	:= $(CFLAGS)
+CXXFLAGS	:= $(CFLAGS) -std=c++23
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-g $(ARCH) $(RPXSPECS) -Wl,-Map,$(notdir $*.map) $(WUPSSPECS) 

--- a/Makefile
+++ b/Makefile
@@ -21,22 +21,28 @@ WUT_ROOT := $(DEVKITPRO)/wut
 #-------------------------------------------------------------------------------
 TARGET		:=	Wii_U_Time_Sync
 BUILD		:=	build
-SOURCES		:=	source
+SOURCES		:=	source source/wupsxx
 DATA		:=	data
 INCLUDES	:=	source
+
+# Be verbose by default.
+V ?= 1
 
 #-------------------------------------------------------------------------------
 # options for code generation
 #-------------------------------------------------------------------------------
-CFLAGS	:=	-Wall -Wextra -Wundef -Wpointer-arith -Wcast-align \
-			-O2 -fipa-pta -pipe -ffunction-sections \
-			$(MACHDEP)
+WARN_FLAGS	:= -Wall -Wextra -Wundef -Wpointer-arith -Wcast-align
 
-CFLAGS	+=	$(INCLUDE) -D__WIIU__ -D__WUT__ -D__WUPS__ 
+OPTFLAGS	:= -O2 -fipa-pta -ffunction-sections
+
+CFLAGS	:=	$(WARN_FLAGS) $(OPTFLAGS) $(MACHDEP)
+
+CPPFLAGS	:= $(INCLUDE) -D__WIIU__ -D__WUT__ -D__WUPS__
 
 CXXFLAGS	:= $(CFLAGS) -std=c++23
 
 ASFLAGS	:=	-g $(ARCH)
+
 LDFLAGS	=	-g $(ARCH) $(RPXSPECS) -Wl,-Map,$(notdir $*.map) $(WUPSSPECS) 
 
 LIBS	:= -lnotifications -lwups -lwut
@@ -92,19 +98,19 @@ export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
 
 export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 
-.PHONY: $(BUILD) clean all
+.PHONY: $(BUILD) clean all upload
 
 #-------------------------------------------------------------------------------
 all: $(BUILD)
 
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
-	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+	$(MAKE) -C $(BUILD) -f $(CURDIR)/Makefile V=$(V)
 
 #-------------------------------------------------------------------------------
 clean:
-	@echo clean ...
-	@rm -fr $(BUILD) $(TARGET).wps $(TARGET).elf
+	$(info clean ...)
+	$(RM) -r $(BUILD) $(TARGET).wps $(TARGET).elf
 
 #-------------------------------------------------------------------------------
 else
@@ -127,8 +133,8 @@ $(OFILES_SRC)	: $(HFILES_BIN)
 #-------------------------------------------------------------------------------
 %.bin.o	%_bin.h :	%.bin
 #-------------------------------------------------------------------------------
-	@echo $(notdir $<)
-	@$(bin2o)
+	$(info $(notdir $<))
+	$(bin2o)
 
 -include $(DEPENDS)
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -3,6 +3,7 @@
 // standard headers
 #include <atomic>
 #include <bit>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -10,6 +11,7 @@
 #include <cstring>
 #include <functional>           // invoke()
 #include <future>
+#include <map>
 #include <memory>               // unique_ptr<>
 #include <numeric>              // accumulate()
 #include <optional>
@@ -42,6 +44,13 @@
 
 #include "ntp.hpp"
 
+#include "wupsxx/bool_item.hpp"
+#include "wupsxx/category.hpp"
+#include "wupsxx/config.hpp"
+#include "wupsxx/int_item.hpp"
+#include "wupsxx/storage.hpp"
+#include "wupsxx/text_item.hpp"
+
 
 using namespace std::literals;
 
@@ -68,60 +77,47 @@ WUPS_USE_STORAGE(PLUGIN_NAME);
 
 
 namespace cfg {
-    int  hours        = 0;
-    int  minutes      = 0;
-    int  msg_duration = 5;
-    bool notify       = false;
-    char server[512]  = "pool.ntp.org";
-    bool sync         = false;
-    int  tolerance    = 250;
+    int         hours        = 0;
+    int         minutes      = 0;
+    int         msg_duration = 5;
+    bool        notify       = false;
+    std::string server       = "pool.ntp.org";
+    bool        sync         = false;
+    int         tolerance    = 250;
 
     OSTime offset = 0;          // combines hours and minutes offsets
 }
 
 
-std::atomic<bool> in_progress = false;
-
-
-// RAII type that handles the in_progress flag.
-
-struct progress_error : std::runtime_error {
-    progress_error() :
-        std::runtime_error{"progress_error"}
-    {}
-};
-
-struct progress_guard {
-    progress_guard()
-    {
-        bool expected_progress = false;
-        if (!in_progress.compare_exchange_strong(expected_progress, true))
-            throw progress_error{};
-    }
-
-    ~progress_guard()
-    {
-        in_progress = false;
-    }
-};
-
-
 // The code below implements a wrapper for std::async() that respects a thread limit.
 
-std::counting_semaphore async_limit{6};
+enum class guard_type {
+    acquire_and_release,
+    only_acquire,
+    only_release
+};
 
 
 template<typename Sem>
-struct semaphore_releaser {
-    Sem& s;
+struct semaphore_guard {
+    Sem& sem;
+    guard_type type;
 
-    semaphore_releaser(Sem& s) :
-        s(s)
-    {}
-
-    ~semaphore_releaser()
+    semaphore_guard(Sem& s,
+                    guard_type t = guard_type::acquire_and_release) :
+        sem(s),
+        type{t}
     {
-        s.release();
+        if (type == guard_type::acquire_and_release ||
+            type == guard_type::only_acquire)
+            sem.acquire();
+    }
+
+    ~semaphore_guard()
+    {
+        if (type == guard_type::acquire_and_release ||
+            type == guard_type::only_release)
+            sem.release();
     }
 };
 
@@ -133,23 +129,25 @@ std::future<typename std::invoke_result_t<std::decay_t<Func>, std::decay_t<Args>
 limited_async(Func&& func,
               Args&&... args)
 {
-    async_limit.acquire();
+    static std::counting_semaphore async_limit{6};
 
-    try {
-        return std::async(std::launch::async,
-                          [](auto&& f, auto&&... a) -> auto
-                          {
-                              semaphore_releaser guard{async_limit};
-                              return std::invoke(std::forward<decltype(f)>(f),
-                                                 std::forward<decltype(a)>(a)...);
-                          },
-                          std::forward<Func>(func),
-                          std::forward<Args>(args)...);
-    }
-    catch (...) {
-        async_limit.release();
-        throw;
-    }
+    semaphore_guard caller_guard{async_limit};
+
+    auto result = std::async(std::launch::async,
+                             [](auto&& f, auto&&... a) -> auto
+                             {
+                                 semaphore_guard callee_guard{async_limit,
+                                                              guard_type::only_release};
+                                 return std::invoke(std::forward<decltype(f)>(f),
+                                                    std::forward<decltype(a)>(a)...);
+                             },
+                             std::forward<Func>(func),
+                             std::forward<Args>(args)...);
+
+    // If async() didn't fail, let the async thread handle the semaphore release.
+    caller_guard.type = guard_type::only_acquire;
+
+    return result;
 }
 
 
@@ -583,20 +581,55 @@ operator <(const struct sockaddr_in& a,
 }
 
 
-void
-update_time()
-try
-{
-    if (!cfg::sync)
-        return;
-        
-    progress_guard guard;
+// RAII type to ensure a function is never executed in parallel.
 
+struct exec_guard {
+    std::atomic<bool>& flag;
+    bool guarded = false;
+
+    exec_guard(std::atomic<bool>& f) :
+        flag(f)
+    {
+        bool expected_flag = false;
+        if (flag.compare_exchange_strong(expected_flag, true))
+            guarded = true; // Exactly one thread can have the "guarded" flag as true.
+    }
+
+    ~exec_guard()
+    {
+        if (guarded)
+            flag = false;
+    }
+};
+
+
+void
+update_offset()
+{
     cfg::offset = OSSecondsToTicks(cfg::minutes * 60);
     if (cfg::hours < 0)
         cfg::offset -= OSSecondsToTicks(-cfg::hours * 60 * 60);
     else
         cfg::offset += OSSecondsToTicks(cfg::hours * 60 * 60);
+}
+
+
+void
+update_time()
+{
+    if (!cfg::sync)
+        return;
+
+    static std::atomic<bool> executing = false;
+
+    exec_guard guard{executing};
+    if (!guard.guarded) {
+        // Another thread is already executing this function.
+        report_info("Skipping NTP task: already in progress.");
+        return;
+    }
+
+    update_offset();
 
     std::vector<std::string> servers = split(cfg::server, " \t,;");
 
@@ -637,7 +670,7 @@ try
             corrections.push_back(correction);
             report_info(to_string(address)
                         + ": correction = "s + seconds_to_human(correction)
-                        + ", latency = "s + seconds_to_human(latency) + "."s);
+                        + ", latency = "s + seconds_to_human(latency));
         }
         catch (std::exception& e) {
             report_error(to_string(address) + ": "s + e.what());
@@ -670,8 +703,18 @@ try
     if (cfg::notify)
         report_success("Clock corrected by " + seconds_to_human(avg_correction));
 }
-catch (progress_error&) {
-    report_info("Skipping NTP task: already in progress.");
+
+
+template<typename T>
+void
+load_or_init(const std::string& key,
+                T& variable)
+{
+    auto val = wups::load<T>(key);
+    if (!val)
+        wups::store(key, variable);
+    else
+        variable = *val;
 }
 
 
@@ -680,27 +723,14 @@ INITIALIZE_PLUGIN()
     WUPSStorageError storageRes = WUPS_OpenStorage();
     // Check if the plugin's settings have been saved before.
     if (storageRes == WUPS_STORAGE_ERROR_SUCCESS) {
-        if (WUPS_GetBool(nullptr, CFG_SYNC, &cfg::sync) == WUPS_STORAGE_ERROR_NOT_FOUND)
-            WUPS_StoreBool(nullptr, CFG_SYNC, cfg::sync);
 
-        if (WUPS_GetBool(nullptr, CFG_NOTIFY, &cfg::notify) == WUPS_STORAGE_ERROR_NOT_FOUND)
-            WUPS_StoreBool(nullptr, CFG_NOTIFY, cfg::notify);
-
-        if (WUPS_GetInt(nullptr, CFG_MSG_DURATION, &cfg::msg_duration) == WUPS_STORAGE_ERROR_NOT_FOUND)
-            WUPS_StoreInt(nullptr, CFG_MSG_DURATION, cfg::msg_duration);
-
-        if (WUPS_GetInt(nullptr, CFG_HOURS, &cfg::hours) == WUPS_STORAGE_ERROR_NOT_FOUND)
-            WUPS_StoreInt(nullptr, CFG_HOURS, cfg::hours);
-
-        if (WUPS_GetInt(nullptr, CFG_MINUTES, &cfg::minutes) == WUPS_STORAGE_ERROR_NOT_FOUND)
-            WUPS_StoreInt(nullptr, CFG_MINUTES, cfg::minutes);
-
-        if (WUPS_GetInt(nullptr, CFG_TOLERANCE, &cfg::tolerance) == WUPS_STORAGE_ERROR_NOT_FOUND)
-            WUPS_StoreInt(nullptr, CFG_TOLERANCE, cfg::tolerance);
-
-        if (WUPS_GetString(nullptr, CFG_SERVER, cfg::server, sizeof cfg::server)
-            == WUPS_STORAGE_ERROR_NOT_FOUND)
-            WUPS_StoreString(nullptr, CFG_SERVER, cfg::server);
+        load_or_init(CFG_HOURS,        cfg::hours);
+        load_or_init(CFG_MINUTES,      cfg::minutes);
+        load_or_init(CFG_MSG_DURATION, cfg::msg_duration);
+        load_or_init(CFG_NOTIFY,       cfg::notify);
+        load_or_init(CFG_SERVER,       cfg::server);
+        load_or_init(CFG_SYNC,         cfg::sync);
+        load_or_init(CFG_TOLERANCE,    cfg::tolerance);
 
         WUPS_CloseStorage();
     }
@@ -712,81 +742,170 @@ INITIALIZE_PLUGIN()
 }
 
 
+struct preview_item : wups::text_item {
+
+    wups::category* category;
+
+    std::map<std::string, wups::text_item*> server_items;
+    std::map<struct sockaddr_in, wups::text_item*> address_items;
+
+
+    preview_item(wups::category* cat) :
+        wups::text_item{"", "Clock", "Press A"},
+        category{cat}
+    {}
+
+
+    void
+    on_button_pressed(WUPSConfigButtons buttons)
+        override
+    {
+        wups::text_item::on_button_pressed(buttons);
+
+        if (buttons & WUPS_CONFIG_BUTTON_A) {
+            try {
+                using std::make_unique;
+
+                update_offset();
+
+                for (auto& [key, value] : server_items)
+                    value->text.clear();
+
+                for (auto& [key, value] : address_items)
+                    value->text.clear();
+
+                std::vector<std::string> servers = split(cfg::server, " \t,;");
+
+                // first, ensure each server has a text_item
+                for (const auto& server : servers)
+                    if (!server_items[server]) {
+                        auto item = make_unique<wups::text_item>("", server);
+                        server_items[server] = item.get();
+                        category->add(std::move(item));
+                    }
+
+                addrinfo_query query = {
+                    .family = AF_INET,
+                    .socktype = SOCK_DGRAM,
+                    .protocol = IPPROTO_UDP
+                };
+
+                std::set<struct sockaddr_in> addresses;
+                for (const auto& server : servers) {
+                    auto item = server_items.at(server);
+                    try {
+                        auto infos = get_address_info(server, "123", query);
+
+                        item->text = std::to_string(infos.size()) + " IP "
+                            + (infos.size() > 1 ? "addresses" : "address");
+
+                        for (auto info : infos)
+                            addresses.insert(info.address);
+                    }
+                    catch (std::exception& e) {
+                        item->text = e.what();
+                    }
+                }
+
+                std::vector<double> corrections;
+                for (auto addr : addresses) {
+                    // ensure each address has a text_item
+                    if (!address_items[addr]) {
+                        auto item = make_unique<wups::text_item>("", to_string(addr));
+                        address_items[addr] = item.get();
+                        category->add(std::move(item));
+                    }
+                    auto item = address_items.at(addr);
+
+                    try {
+                        auto [correction, latency] = ntp_query(addr);
+                        item->text += "correction = " + seconds_to_human(correction)
+                            + ", latency = " + seconds_to_human(latency);
+
+                        corrections.push_back(correction);
+                    }
+                    catch (std::exception& e) {
+                        item->text = e.what();
+                    }
+                }
+
+                text = format_wiiu_time(OSGetTime());
+
+                if (corrections.empty())
+                    text += ": no NTP server could be used.";
+                else {
+                    double avg_correction = std::accumulate(corrections.begin(),
+                                                            corrections.end(),
+                                                            0.0)
+                        / corrections.size();
+                    text += " is off by "s + seconds_to_human(avg_correction);
+                }
+
+            }
+            catch (std::exception& e) {
+                text = "Error: "s + e.what();
+            }
+
+        }
+
+    }
+
+};
+
+
 WUPS_GET_CONFIG()
 {
     if (WUPS_OpenStorage() != WUPS_STORAGE_ERROR_SUCCESS)
         return 0;
 
-    WUPSConfigHandle settings;
-    WUPSConfig_CreateHandled(&settings, PLUGIN_NAME);
+    using std::make_unique;
 
-    WUPSConfigCategoryHandle config;
-    WUPSConfig_AddCategoryByNameHandled(settings, "Configuration", &config);
-    WUPSConfigCategoryHandle preview;
-    WUPSConfig_AddCategoryByNameHandled(settings, "Preview Time", &preview);
+    try {
 
-    WUPSConfigItemBoolean_AddToCategoryHandled(settings, config, CFG_SYNC,
-                                               "Syncing Enabled",
-                                               cfg::sync,
-                                               [](ConfigItemBoolean*, bool value)
-                                               {
-                                                   WUPS_StoreBool(nullptr, CFG_SYNC, value);
-                                                   cfg::sync = value;
-                                               });
-    WUPSConfigItemBoolean_AddToCategoryHandled(settings, config, CFG_NOTIFY,
-                                               "Show Notifications",
-                                               cfg::notify,
-                                               [](ConfigItemBoolean*, bool value)
-                                               {
-                                                   WUPS_StoreBool(nullptr, CFG_NOTIFY, value);
-                                                   cfg::notify = value;
-                                               });
-    WUPSConfigItemIntegerRange_AddToCategoryHandled(settings, config, CFG_HOURS,
-                                                    "Time Offset (hours)",
-                                                    cfg::hours, -12, 14,
-                                                    [](ConfigItemIntegerRange*, int32_t value)
-                                                    {
-                                                        WUPS_StoreInt(nullptr, CFG_HOURS, value);
-                                                        cfg::hours = value;
-                                                    });
-    WUPSConfigItemIntegerRange_AddToCategoryHandled(settings, config, CFG_MINUTES,
-                                                    "Time Offset (minutes)",
-                                                    cfg::minutes, 0, 59,
-                                                    [](ConfigItemIntegerRange*, int32_t value)
-                                                    {
-                                                        WUPS_StoreInt(nullptr, CFG_MINUTES,
-                                                                      value);
-                                                        cfg::minutes = value;
-                                                    });
-    WUPSConfigItemIntegerRange_AddToCategoryHandled(settings, config, CFG_MSG_DURATION,
-                                                    "Message Duration (seconds)",
-                                                    cfg::msg_duration, 0, 30,
-                                                    [](ConfigItemIntegerRange*, int32_t value)
-                                                    {
-                                                        WUPS_StoreInt(nullptr, CFG_MSG_DURATION,
-                                                                      value);
-                                                        cfg::msg_duration = value;
-                                                    });
-    WUPSConfigItemIntegerRange_AddToCategoryHandled(settings, config, CFG_TOLERANCE,
-                                                    "Tolerance (milliseconds)",
-                                                    cfg::tolerance, 0, 5000,
-                                                    [](ConfigItemIntegerRange*, int32_t value)
-                                                    {
-                                                        WUPS_StoreInt(nullptr, CFG_TOLERANCE,
-                                                                      value);
-                                                        cfg::tolerance = value;
-                                                    });
+        auto config = make_unique<wups::category>("Configuration");
+        auto preview = make_unique<wups::category>("Preview");
 
-    // show current NTP server address, no way to change it.
-    std::string server = "NTP Servers: "s + cfg::server;
-    WUPSConfigItemStub_AddToCategoryHandled(settings, config, CFG_SERVER, server.c_str());
+        config->add(make_unique<wups::bool_item>(CFG_SYNC,
+                                                 "Syncing Enabled",
+                                                 cfg::sync));
 
-    // Prepare the time to be shown for the user.
-    std::string time = "Current Time: "s + format_wiiu_time(OSGetTime());
-    WUPSConfigItemStub_AddToCategoryHandled(settings, preview, "time",
-                                            time.c_str());
+        config->add(make_unique<wups::bool_item>(CFG_NOTIFY,
+                                                 "Show Notifications",
+                                                 cfg::notify));
 
-    return settings;
+        config->add(make_unique<wups::int_item>(CFG_MSG_DURATION,
+                                                "Notification Duration (seconds)",
+                                                cfg::msg_duration, 0, 30));
+
+        config->add(make_unique<wups::int_item>(CFG_HOURS,
+                                                "Hours Offset",
+                                                cfg::hours, -12, 14));
+
+        config->add(make_unique<wups::int_item>(CFG_MINUTES,
+                                                "Minutes Offset",
+                                                cfg::minutes, 0, 59));
+
+        config->add(make_unique<wups::int_item>(CFG_TOLERANCE,
+                                                "Tolerance (milliseconds, L/R for +/- 50)",
+                                                cfg::tolerance, 0, 5000));
+
+        // show current NTP server address, no way to change it.
+        config->add(make_unique<wups::text_item>(CFG_SERVER,
+                                                 "NTP servers",
+                                                 cfg::server));
+
+        preview->add(make_unique<preview_item>(preview.get()));
+
+        auto root = make_unique<wups::config>(PLUGIN_NAME);
+        root->add(std::move(config));
+        root->add(std::move(preview));
+
+        return root.release()->handle;
+
+    }
+    catch (...) {
+        return 0;
+    }
 }
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -727,8 +727,8 @@ WUPS_GET_CONFIG()
                                                cfg::sync,
                                                [](ConfigItemBoolean*, bool value)
                                                {
-                                                   WUPS_StoreBool(nullptr, CFG_NOTIFY, value);
-                                                   cfg::notify = value;
+                                                   WUPS_StoreBool(nullptr, CFG_SYNC, value);
+                                                   cfg::sync = value;
                                                });
     WUPSConfigItemBoolean_AddToCategoryHandled(settings, config, CFG_NOTIFY,
                                                "Show Notifications",

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,318 +1,794 @@
+// SPDX-License-Identifier: MIT
+
+// standard headers
+#include <atomic>
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <functional>           // invoke()
+#include <future>
+#include <memory>               // unique_ptr<>
+#include <numeric>              // accumulate()
+#include <optional>
+#include <ranges>               // ranges::zip()
+#include <semaphore>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>              // pair<>
+#include <vector>
+
+// unix headers
 #include <arpa/inet.h>
-#include <malloc.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <string.h>
+#include <sys/select.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
 
-#include <coreinit/debug.h>
-#include <coreinit/filesystem.h>
-#include <coreinit/ios.h>
-#include <coreinit/mcp.h>
+// WUT/WUPS headers
 #include <coreinit/time.h>
 #include <nn/pdm.h>
 #include <notifications/notifications.h>
-#include <whb/proc.h>
 #include <wups.h>
 #include <wups/config/WUPSConfigItemBoolean.h>
-#include <wups/config/WUPSConfigItemStub.h>
 #include <wups/config/WUPSConfigItemIntegerRange.h>
+#include <wups/config/WUPSConfigItemStub.h>
 
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
-#include <thread>
+#include "ntp.hpp"
 
-#define SYNCING_ENABLED_CONFIG_ID "enabledSync"
-#define DST_ENABLED_CONFIG_ID "enabledDST"
-#define NOTIFY_ENABLED_CONFIG_ID "enabledNotify"
-#define OFFSET_HOURS_CONFIG_ID "offsetHours"
-#define OFFSET_MINUTES_CONFIG_ID "offsetMinutes"
-// Seconds between 1900 (NTP epoch) and 2000 (Wii U epoch)
-#define NTP_TIMESTAMP_DELTA 3155673600llu
+
+using namespace std::literals;
+
+
+#define PLUGIN_NAME "Wii U Time Sync"
+
+#define CFG_HOURS        "hours"
+#define CFG_MINUTES      "minutes"
+#define CFG_MSG_DURATION "msg_duration"
+#define CFG_NOTIFY       "notify"
+#define CFG_SERVER       "server"
+#define CFG_SYNC         "sync"
+#define CFG_TOLERANCE    "tolerance"
 
 // Important plugin information.
-WUPS_PLUGIN_NAME("Wii U Time Sync");
+WUPS_PLUGIN_NAME(PLUGIN_NAME);
 WUPS_PLUGIN_DESCRIPTION("A plugin that synchronizes a Wii U's clock to the Internet.");
 WUPS_PLUGIN_VERSION("v1.1.0");
-WUPS_PLUGIN_AUTHOR("Nightkingale");
+WUPS_PLUGIN_AUTHOR("Nightkingale, Daniel K. O.");
 WUPS_PLUGIN_LICENSE("MIT");
 
 WUPS_USE_WUT_DEVOPTAB();
-WUPS_USE_STORAGE("Wii U Time Sync");
+WUPS_USE_STORAGE(PLUGIN_NAME);
 
-bool enabledSync = false;
-bool enabledDST = false;
-bool enabledNotify = true;
-int offsetHours = 0;
-int offsetMinutes = 0;
 
-// From https://github.com/lettier/ntpclient/blob/master/source/c/main.c
-typedef struct
+namespace cfg {
+    int  hours        = 0;
+    int  minutes      = 0;
+    int  msg_duration = 5;
+    bool notify       = true;
+    char server[512]  = "pool.ntp.org";
+    bool sync         = false;
+    int  tolerance    = 200;
+
+    OSTime offset = 0;          // combines hours and minutes offsets
+}
+
+
+std::atomic<bool> in_progress = false;
+
+
+// RAII type that handles the in_progress flag.
+
+struct progress_error : std::runtime_error {
+    progress_error() :
+        std::runtime_error{"progress_error"}
+    {}
+};
+
+struct progress_guard {
+    progress_guard()
+    {
+        bool expected_progress = false;
+        if (!in_progress.compare_exchange_strong(expected_progress, true))
+            throw progress_error{};
+    }
+
+    ~progress_guard()
+    {
+        in_progress = false;
+    }
+};
+
+
+// The code below implements a wrapper for std::async() that respects a thread limit.
+
+std::counting_semaphore async_limit{6};
+
+
+template<typename Sem>
+struct semaphore_releaser {
+    Sem& s;
+
+    semaphore_releaser(Sem& s) :
+        s(s)
+    {}
+
+    ~semaphore_releaser()
+    {
+        s.release();
+    }
+};
+
+
+template<typename Func,
+         typename... Args>
+[[nodiscard]]
+std::future<typename std::invoke_result_t<std::decay_t<Func>, std::decay_t<Args>...>>
+limited_async(Func&& func,
+              Args&&... args)
 {
-    uint8_t li_vn_mode;      // Eight bits. li, vn, and mode.
-                                // li.   Two bits.   Leap indicator.
-                                // vn.   Three bits. Version number of the protocol.
-                                // mode. Three bits. Client will pick mode 3 for client.
+    async_limit.acquire();
 
-    uint8_t stratum;         // Eight bits. Stratum level of the local clock.
-    uint8_t poll;            // Eight bits. Maximum interval between successive messages.
-    uint8_t precision;       // Eight bits. Precision of the local clock.
+    try {
+        return std::async(std::launch::async,
+                          [](auto&& f, auto&&... a) -> auto
+                          {
+                              semaphore_releaser guard{async_limit};
+                              return std::invoke(std::forward<decltype(f)>(f),
+                                                 std::forward<decltype(a)>(a)...);
+                          },
+                          std::forward<Func>(func),
+                          std::forward<Args>(args)...);
+    }
+    catch (...) {
+        async_limit.release();
+        throw;
+    }
+}
 
-    uint32_t rootDelay;      // 32 bits. Total round trip delay time.
-    uint32_t rootDispersion; // 32 bits. Max error aloud from primary clock source.
-    uint32_t refId;          // 32 bits. Reference clock identifier.
 
-    uint32_t refTm_s;        // 32 bits. Reference time-stamp seconds.
-    uint32_t refTm_f;        // 32 bits. Reference time-stamp fraction of a second.
+#ifdef __WUT__
+// These can usually be found in <endian.h>, but WUT does not provide them.
 
-    uint32_t origTm_s;       // 32 bits. Originate time-stamp seconds.
-    uint32_t origTm_f;       // 32 bits. Originate time-stamp fraction of a second.
-
-    uint32_t rxTm_s;         // 32 bits. Received time-stamp seconds.
-    uint32_t rxTm_f;         // 32 bits. Received time-stamp fraction of a second.
-
-    uint32_t txTm_s;         // 32 bits and the most important field the client cares about. Transmit time-stamp seconds.
-    uint32_t txTm_f;         // 32 bits. Transmit time-stamp fraction of a second.
-
-} ntp_packet;              // Total: 384 bits or 48 bytes.
-
-extern "C" int32_t CCRSysSetSystemTime(OSTime time);
-extern "C" BOOL __OSSetAbsoluteSystemTime(OSTime time);
-
-bool SetSystemTime(OSTime time)
+constexpr
+std::uint64_t
+htobe64(std::uint64_t x)
 {
+    if constexpr (std::endian::native == std::endian::big)
+        return x;
+    else
+        return std::byteswap(x);
+}
+
+
+constexpr
+std::uint64_t
+be64toh(std::uint64_t x)
+{
+    return htobe64(x);
+}
+
+#endif
+
+
+void
+report_error(const std::string& arg)
+{
+    std::string msg = "[" PLUGIN_NAME "] " + arg;
+    NotificationModule_AddErrorNotificationEx(msg.c_str(),
+                                              cfg::msg_duration,
+                                              1,
+                                              {255, 255, 255, 255},
+                                              {160, 32, 32, 255},
+                                              nullptr,
+                                              nullptr);
+}
+
+
+void
+report_info(const std::string& arg)
+{
+    if (!cfg::notify)
+        return;
+
+    std::string msg = "[" PLUGIN_NAME "] " + arg;
+    NotificationModule_AddInfoNotificationEx(msg.c_str(),
+                                             cfg::msg_duration,
+                                             {255, 255, 255, 255},
+                                             {32, 32, 160, 255},
+                                             nullptr,
+                                             nullptr);
+}
+
+
+void
+report_success(const std::string& arg)
+{
+    if (!cfg::notify)
+        return;
+
+    std::string msg = "[" PLUGIN_NAME "] " + arg;
+    NotificationModule_AddInfoNotificationEx(msg.c_str(),
+                                             cfg::msg_duration,
+                                             {255, 255, 255, 255},
+                                             {32, 160, 32, 255},
+                                             nullptr,
+                                             nullptr);
+}
+
+
+// Wrapper for strerror_r()
+std::string
+errno_to_string(int e)
+{
+    char buf[100];
+    strerror_r(e, buf, sizeof buf);
+    return buf;
+}
+
+
+OSTime
+get_utc_time()
+{
+    return OSGetTime() - cfg::offset;
+}
+
+
+double
+ntp_to_double(ntp::timestamp t)
+{
+    return std::ldexp(static_cast<double>(t), -32);
+}
+
+
+ntp::timestamp
+double_to_ntp(double t)
+{
+    return std::ldexp(t, 32);
+}
+
+
+OSTime
+ntp_to_wiiu(ntp::timestamp t)
+{
+    // Change t from NTP epoch (1900) to Wii U epoch (2000).
+    // There are 24 leap years in this period.
+    constexpr std::uint64_t seconds_per_day = 24 * 60 * 60;
+    constexpr std::uint64_t seconds_offset = seconds_per_day * (100 * 365 + 24);
+    t -= seconds_offset << 32;
+
+    // Convert from u32.32 to Wii U ticks count.
+    double dt = ntp_to_double(t);
+
+    // Note: do the conversion in floating point to avoid overflows.
+    OSTime r = dt * OSTimerClockSpeed;
+
+    return r;
+}
+
+
+ntp::timestamp
+wiiu_to_ntp(OSTime t)
+{
+    // Convert from Wii U ticks to seconds.
+    // Note: do the conversion in floating point to avoid overflows.
+    double dt = static_cast<double>(t) / OSTimerClockSpeed;
+    ntp::timestamp r = double_to_ntp(dt);
+
+    // Change r from Wii U epoch (2000) to NTP epoch (1900).
+    constexpr std::uint64_t seconds_per_day = 24 * 60 * 60;
+    constexpr std::uint64_t seconds_offset = seconds_per_day * (100 * 365 + 24);
+    r += seconds_offset << 32;
+
+    return r;
+}
+
+
+std::string
+to_string(const struct sockaddr_in& addr)
+{
+    char buf[32];
+    return inet_ntop(addr.sin_family, &addr.sin_addr,
+                     buf, sizeof buf);
+}
+
+
+std::string
+seconds_to_human(double s)
+{
+    char buf[64];
+
+    if (std::fabs(s) < 2) // less than 2 seconds
+        std::snprintf(buf, sizeof buf, "%.3f ms", 1000 * s);
+    else if (std::fabs(s) < 2 * 60) // less than 2 minutes
+        std::snprintf(buf, sizeof buf, "%.1f s", s);
+    else if (std::fabs(s) < 2 * 60 * 60) // less than 2 hours
+        std::snprintf(buf, sizeof buf, "%.1f min", s / 60);
+    else if (std::fabs(s) < 2 * 24 * 60 * 60) // less than 2 days
+        std::snprintf(buf, sizeof buf, "%.1f hrs", s / (60 * 60));
+    else
+        std::snprintf(buf, sizeof buf, "%.1f days", s / (24 * 60 * 60));
+
+    return buf;
+}
+
+
+std::string
+format_wiiu_time(OSTime wt)
+{
+    OSCalendarTime cal;
+    OSTicksToCalendarTime(wt, &cal);
+    char buffer[256];
+    std::snprintf(buffer, sizeof buffer,
+                  "%04d-%02d-%02d %02d:%02d:%02d.%03d",
+                  cal.tm_year, cal.tm_mon + 1, cal.tm_mday,
+                  cal.tm_hour, cal.tm_min, cal.tm_sec, cal.tm_msec);
+    return buffer;
+}
+
+
+std::string
+format_ntp(ntp::timestamp t)
+{
+    OSTime wt = ntp_to_wiiu(t);
+    return format_wiiu_time(wt);
+}
+
+
+std::vector<std::string>
+split(const std::string& input,
+      const std::string& separators)
+{
+    using std::string;
+
+    std::vector<string> result;
+
+    string::size_type start = 0;
+    while (start != string::npos) {
+        auto finish = input.find_first_of(separators, start);
+        result.push_back(input.substr(start, finish - start));
+        start = input.find_first_not_of(separators, finish);
+    }
+
+    return result;
+}
+
+
+extern "C" int32_t CCRSysSetSystemTime(OSTime time); // from nn_ccr
+extern "C" BOOL __OSSetAbsoluteSystemTime(OSTime time); // from coreinit
+
+
+bool
+apply_clock_correction(double correction)
+{
+    OSTime correction_ticks = correction * OSTimerClockSpeed;
+
+    OSTime now = OSGetTime();
+    OSTime corrected = now + correction_ticks;
+
     nn::pdm::NotifySetTimeBeginEvent();
 
-    if (CCRSysSetSystemTime(time) != 0) {
+    if (CCRSysSetSystemTime(corrected)) {
         nn::pdm::NotifySetTimeEndEvent();
         return false;
     }
 
-    BOOL res = __OSSetAbsoluteSystemTime(time);
+    bool res = __OSSetAbsoluteSystemTime(corrected);
 
     nn::pdm::NotifySetTimeEndEvent();
 
-    return res != FALSE;
+    return res;
 }
 
-OSTime NTPGetTime(const char* hostname)
+
+// RAII class to close down a socket
+struct socket_guard {
+    int fd;
+
+    socket_guard(int ns, int st, int pr) :
+        fd{socket(ns, st, pr)}
+    {}
+
+    ~socket_guard()
+    {
+        if (fd != -1)
+            close();
+    }
+
+    void
+    close()
+    {
+        ::close(fd);
+        fd = -1;
+    }
+};
+
+
+// Note: hardcoded for IPv4, the Wii U doesn't have IPv6.
+std::pair<double, double>
+ntp_query(struct sockaddr_in address)
 {
-    ntp_packet packet;
-    memset(&packet, 0, sizeof(packet));
+    socket_guard s{PF_INET, SOCK_DGRAM, IPPROTO_UDP};
+    if (s.fd == -1)
+        throw std::runtime_error{"unable to create socket"};
 
-    // Set the first byte's bits to 00,011,011 for li = 0, vn = 3, and mode = 3. The rest will be left set to zero.
-    packet.li_vn_mode = 0x1b;
+    connect(s.fd, reinterpret_cast<struct sockaddr*>(&address), sizeof address);
 
-    // Create a socket
-    int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-    if (sockfd < 0) {
-        return 0;
+    ntp::packet packet;
+    packet.version(4);
+    packet.mode(ntp::packet::mode::client);
+
+
+    unsigned num_send_tries = 0;
+ try_again_send:
+
+    ntp::timestamp t1 = wiiu_to_ntp(get_utc_time());
+    packet.transmit_time = htobe64(t1);
+
+    if (send(s.fd, &packet, sizeof packet, 0) == -1) {
+        int e = errno;
+        if (e != ENOMEM)
+            throw std::runtime_error{"unable to send NTP request: "s + errno_to_string(e)};
+        if (++num_send_tries < 4) {
+            std::this_thread::sleep_for(100ms);
+            goto try_again_send;
+        } else
+            throw std::runtime_error{"no resources for send(), too many retries"};
     }
 
-    // Get host address by name
-    struct hostent* server = gethostbyname(hostname);
-    if (!server) {
-        return 0;
+    struct timeval timeout = { 4, 0 };
+    fd_set read_set;
+
+
+    unsigned num_select_tries = 0;
+ try_again_select:
+
+    FD_ZERO(&read_set);
+    FD_SET(s.fd, &read_set);
+
+    if (select(s.fd + 1, &read_set, nullptr, nullptr, &timeout) == -1) {
+        // Wii U's OS can only handle 16 concurrent select() calls,
+        // so we may need to try again later.
+        int e = errno;
+        if (e != ENOMEM)
+            throw std::runtime_error{"select() failed: "s + errno_to_string(e)};
+        if (++num_select_tries < 4) {
+            std::this_thread::sleep_for(10ms);
+            goto try_again_select;
+        } else
+            throw std::runtime_error{"no resources for select(), too many retries"};
     }
 
-    // Prepare socket address
-    struct sockaddr_in serv_addr;
-    memset(&serv_addr, 0, sizeof(serv_addr));
-    serv_addr.sin_family = AF_INET;
 
-    // Copy the server's IP address to the server address structure.
-    memcpy(&serv_addr.sin_addr.s_addr, server->h_addr, server->h_length);
+    if (!FD_ISSET(s.fd, &read_set))
+        throw std::runtime_error{"timeout reached"};
 
-    // Convert the port number integer to network big-endian style and save it to the server address structure.
-    serv_addr.sin_port = htons(123); // UDP port
+    if (recv(s.fd, &packet, sizeof packet, 0) < 48)
+        throw std::runtime_error{"invalid NTP response"};
 
-    // Call up the server using its IP address and port number.
-    if (connect(sockfd, (struct sockaddr*) &serv_addr, sizeof(serv_addr)) < 0) {
-        close(sockfd);
-        return 0;
-    }
+    ntp::timestamp t4 = wiiu_to_ntp(get_utc_time());
 
-    // Send it the NTP packet it wants. If n == -1, it failed.
-    if (write(sockfd, &packet, sizeof(packet)) < 0) {
-        close(sockfd);
-        return 0;
-    }
+    ntp::timestamp t1_copy = be64toh(packet.origin_time);
+    if (t1 != t1_copy)
+        throw std::runtime_error{"NTP response does not match request: ["s
+                                 + format_ntp(t1) + "] vs ["s
+                                 + format_ntp(t1_copy) + "]"s};
 
-    // Wait and receive the packet back from the server. If n == -1, it failed.
-    if (read(sockfd, &packet, sizeof(packet)) < 0) {
-        close(sockfd);
-        return 0;
-    }
+    // when our request arrived at the server
+    ntp::timestamp t2 = be64toh(packet.receive_time);
+    // when the server sent out a response
+    ntp::timestamp t3 = be64toh(packet.transmit_time);
 
-    // Close the socket
-    close(sockfd);
+    double roundtrip = ntp_to_double((t4 - t1) - (t3 - t2));
+    double latency = roundtrip / 2;
 
-    // These two fields contain the time-stamp seconds as the packet left the NTP server.
-    // The number of seconds correspond to the seconds passed since 1900.
-    // ntohl() converts the bit/byte order from the network's to host's "endianness".
-    packet.txTm_s = ntohl(packet.txTm_s); // Time-stamp seconds.
-    packet.txTm_f = ntohl(packet.txTm_f); // Time-stamp fraction of a second.
+    // t4 + correction = t3 + latency
+    double correction = ntp_to_double(t3) + latency - ntp_to_double(t4);
 
-    OSTime tick = 0;
-    // Convert seconds to ticks and adjust timestamp
-    tick += OSSecondsToTicks(packet.txTm_s - NTP_TIMESTAMP_DELTA);
-    // Convert fraction to ticks
-    tick += OSNanosecondsToTicks((packet.txTm_f * 1000000000llu) >> 32);
-    return tick;
+    return { correction, latency };
 }
 
-void updateTime() {
-    uint64_t roundtripStart = 0;
-    uint64_t roundtripEnd = 0;
 
-    // Get the time from the server.
-    roundtripStart = OSGetTime();
-    OSTime time = NTPGetTime("pool.ntp.org"); // Connect to the time server.
-    roundtripEnd = OSGetTime();
+// Wrapper for getaddrinfo(), hardcoded for IPv4
 
-    if (time == 0) {
-        return; // Probably didn't connect correctly.
+struct addrinfo_query {
+    int flags    = 0;
+    int family   = AF_UNSPEC;
+    int socktype = 0;
+    int protocol = 0;
+};
+
+
+struct addrinfo_result {
+    int                        family;
+    int                        socktype;
+    int                        protocol;
+    struct sockaddr_in         address;
+    std::optional<std::string> canonname;
+};
+
+
+std::vector<addrinfo_result>
+get_address_info(const std::optional<std::string>& name,
+                 const std::optional<std::string>& port = {},
+                 std::optional<addrinfo_query> query = {})
+{
+    // RAII: unique_ptr is used to invoke freeaddrinfo() on function exit
+    std::unique_ptr<struct addrinfo,
+                    decltype([](struct addrinfo* p) { freeaddrinfo(p); })>
+        info;
+
+    {
+        struct addrinfo hints;
+        const struct addrinfo *hints_ptr = nullptr;
+
+        if (query) {
+            hints_ptr = &hints;
+            std::memset(&hints, 0, sizeof hints);
+            hints.ai_flags = query->flags;
+            hints.ai_family = query->family;
+            hints.ai_socktype = query->socktype;
+            hints.ai_protocol = query->protocol;
+        }
+
+        struct addrinfo* raw_info = nullptr;
+        int err = getaddrinfo(name ? name->c_str() : nullptr,
+                              port ? port->c_str() : nullptr,
+                              hints_ptr,
+                              &raw_info);
+        if (err)
+            throw std::runtime_error{gai_strerror(err)};
+
+        info.reset(raw_info); // put it in the smart pointer
     }
 
-    // Calculate the roundtrip time.
-    uint64_t roundtrip = roundtripEnd - roundtripStart;
+    std::vector<addrinfo_result> result;
 
-    // Calculate the time it took to get the time from the server.
-    uint64_t timeTook = roundtrip / 2;
+    // walk through the linked list
+    for (auto a = info.get(); a; a = a->ai_next) {
 
-    // Subtract the time it took to get the time from the server.
-    time -= timeTook;
+        // sanity check: Wii U only supports IPv4
+        if (a->ai_addrlen != sizeof(struct sockaddr_in))
+            throw std::logic_error{"getaddrinfo() returned invalid result"};
 
-    if (offsetHours < 0) {
-        time -= OSSecondsToTicks(abs(offsetHours) * 60 * 60);
-    } else {
-        time += OSSecondsToTicks(offsetHours * 60 * 60);
+        addrinfo_result item;
+        item.family = a->ai_family;
+        item.socktype = a->ai_socktype;
+        item.protocol = a->ai_protocol,
+        std::memcpy(&item.address, a->ai_addr, sizeof item.address);
+        if (a->ai_canonname)
+            item.canonname = a->ai_canonname;
+
+        result.push_back(std::move(item));
     }
 
-    if (enabledDST) {
-        time += OSSecondsToTicks(60 * 60); // DST adds an hour.
-    }
-
-    time += OSSecondsToTicks(offsetMinutes * 60);
-
-    OSTime currentTime = OSGetTime();
-    int timeDifference = abs(time - currentTime);
-
-    if (static_cast<uint64_t>(timeDifference) <= OSMillisecondsToTicks(250)) {
-        return; // Time difference is within 250 milliseconds, no need to update.
-    }
-
-    SetSystemTime(time); // This finally sets the console time.
-
-    if (enabledNotify) {
-        NotificationModule_AddInfoNotification("The time has been changed based on your Internet connection.");
-    }
+    return result;
 }
 
-INITIALIZE_PLUGIN() {
+
+// ordering operator, so we can put sockaddr_in inside a std::set.
+constexpr
+bool
+operator <(const struct sockaddr_in& a,
+           const struct sockaddr_in& b)
+    noexcept
+{
+    return a.sin_addr.s_addr < b.sin_addr.s_addr;
+}
+
+
+void
+update_time()
+try
+{
+    progress_guard guard;
+
+    cfg::offset = OSSecondsToTicks(cfg::minutes * 60);
+    if (cfg::hours < 0)
+        cfg::offset -= OSSecondsToTicks(-cfg::hours * 60 * 60);
+    else
+        cfg::offset += OSSecondsToTicks(cfg::hours * 60 * 60);
+
+    std::vector<std::string> servers = split(cfg::server, " \t,;");
+
+    addrinfo_query query = {
+        .family = AF_INET,
+        .socktype = SOCK_DGRAM,
+        .protocol = IPPROTO_UDP
+    };
+
+    // First, resolve all the names, in parallel.
+    // Some IP addresses might be duplicated when we use *.pool.ntp.org.
+    std::set<struct sockaddr_in> addresses;
+    {
+        std::vector<std::future<std::vector<addrinfo_result>>> infos(servers.size());
+        for (auto [info_vec, server] : std::views::zip(infos, servers))
+            info_vec = limited_async(get_address_info, server, "123", query);
+
+        for (auto& info_vec : infos)
+            try {
+                for (auto info : info_vec.get())
+                    addresses.insert(info.address);
+            }
+            catch (std::exception& e) {
+                report_error(e.what());
+            }
+    }
+
+    // Launch all NTP queries in parallel.
+    std::vector<std::future<std::pair<double, double>>> results(addresses.size());
+    for (auto [address, result] : std::views::zip(addresses, results))
+        result = limited_async(ntp_query, address);
+
+    // Now collect all results.
+    std::vector<double> corrections;
+    for (auto [address, result] : std::views::zip(addresses, results))
+        try {
+            auto [correction, latency] = result.get();
+            corrections.push_back(correction);
+            report_info(to_string(address)
+                        + ": correction = "s + seconds_to_human(correction)
+                        + ",  latency = "s + seconds_to_human(latency));
+        }
+        catch (std::exception& e) {
+            report_error(to_string(address) + ": "s + e.what());
+        }
+
+
+    if (corrections.empty()) {
+        report_error("no NTP server could be used");
+        return;
+    }
+
+    double avg_correction = std::accumulate(corrections.begin(),
+                                            corrections.end(),
+                                            0.0)
+        / corrections.size();
+
+    if (std::fabs(avg_correction) * 1000 <= cfg::tolerance) {
+        report_success("tolerating clock drift (correction is only "
+                       + seconds_to_human(avg_correction) + ")"s);
+        return;
+    }
+
+    if (cfg::sync) {
+        if (!apply_clock_correction(avg_correction)) {
+            report_error("failed to set system clock");
+            return;
+        }
+    }
+
+    if (cfg::notify)
+        report_success("clock corrected by " + seconds_to_human(avg_correction));
+}
+catch (progress_error&) {
+    report_info("skipping NTP task: already in progress");
+}
+
+
+INITIALIZE_PLUGIN()
+{
     WUPSStorageError storageRes = WUPS_OpenStorage();
     // Check if the plugin's settings have been saved before.
     if (storageRes == WUPS_STORAGE_ERROR_SUCCESS) {
-        if ((storageRes = WUPS_GetBool(nullptr, SYNCING_ENABLED_CONFIG_ID, &enabledSync)) == WUPS_STORAGE_ERROR_NOT_FOUND) {
-            WUPS_StoreBool(nullptr, SYNCING_ENABLED_CONFIG_ID, enabledSync);
-        }
+        if (WUPS_GetBool(nullptr, CFG_SYNC, &cfg::sync) == WUPS_STORAGE_ERROR_NOT_FOUND)
+            WUPS_StoreBool(nullptr, CFG_SYNC, cfg::sync);
 
-        if ((storageRes = WUPS_GetBool(nullptr, DST_ENABLED_CONFIG_ID, &enabledDST)) == WUPS_STORAGE_ERROR_NOT_FOUND) {
-            WUPS_StoreBool(nullptr, DST_ENABLED_CONFIG_ID, enabledDST);
-        }
+        if (WUPS_GetBool(nullptr, CFG_NOTIFY, &cfg::notify) == WUPS_STORAGE_ERROR_NOT_FOUND)
+            WUPS_StoreBool(nullptr, CFG_NOTIFY, cfg::notify);
 
-        if ((storageRes = WUPS_GetBool(nullptr, NOTIFY_ENABLED_CONFIG_ID, &enabledNotify)) == WUPS_STORAGE_ERROR_NOT_FOUND) {
-            WUPS_StoreBool(nullptr, NOTIFY_ENABLED_CONFIG_ID, enabledNotify);
-        }
+        if (WUPS_GetInt(nullptr, CFG_MSG_DURATION, &cfg::msg_duration) == WUPS_STORAGE_ERROR_NOT_FOUND)
+            WUPS_StoreInt(nullptr, CFG_MSG_DURATION, cfg::msg_duration);
 
-        if ((storageRes = WUPS_GetInt(nullptr, OFFSET_HOURS_CONFIG_ID, &offsetHours)) == WUPS_STORAGE_ERROR_NOT_FOUND) {
-            WUPS_StoreInt(nullptr, OFFSET_HOURS_CONFIG_ID, offsetHours);
-        }
+        if (WUPS_GetInt(nullptr, CFG_HOURS, &cfg::hours) == WUPS_STORAGE_ERROR_NOT_FOUND)
+            WUPS_StoreInt(nullptr, CFG_HOURS, cfg::hours);
 
-        if ((storageRes = WUPS_GetInt(nullptr, OFFSET_MINUTES_CONFIG_ID, &offsetMinutes)) == WUPS_STORAGE_ERROR_NOT_FOUND) {
-            WUPS_StoreInt(nullptr, OFFSET_MINUTES_CONFIG_ID, offsetMinutes);
-        }
+        if (WUPS_GetInt(nullptr, CFG_MINUTES, &cfg::minutes) == WUPS_STORAGE_ERROR_NOT_FOUND)
+            WUPS_StoreInt(nullptr, CFG_MINUTES, cfg::minutes);
 
-        NotificationModule_InitLibrary(); // Set up for notifications.
-        WUPS_CloseStorage(); // Close the storage.
+        if (WUPS_GetInt(nullptr, CFG_TOLERANCE, &cfg::tolerance) == WUPS_STORAGE_ERROR_NOT_FOUND)
+            WUPS_StoreInt(nullptr, CFG_TOLERANCE, cfg::tolerance);
+
+        if (WUPS_GetString(nullptr, CFG_SERVER, cfg::server, sizeof cfg::server)
+            == WUPS_STORAGE_ERROR_NOT_FOUND)
+            WUPS_StoreString(nullptr, CFG_SERVER, cfg::server);
+
+        WUPS_CloseStorage();
     }
 
-    if (enabledSync) {
-        updateTime(); // Update time when plugin is loaded.
-    }
+    NotificationModule_InitLibrary(); // Set up for notifications.
+
+    if (cfg::sync)
+        update_time(); // Update time when plugin is loaded.
 }
 
-void syncingEnabled(ConfigItemBoolean *item, bool value)
+
+WUPS_GET_CONFIG()
 {
-    (void)item;
-    // If false, bro is literally a time traveler!
-    WUPS_StoreBool(nullptr, SYNCING_ENABLED_CONFIG_ID, value);
-    enabledSync = value;
-}
-
-void savingsEnabled(ConfigItemBoolean *item, bool value)
-{
-    (void)item;
-    WUPS_StoreBool(nullptr, DST_ENABLED_CONFIG_ID, value);
-    enabledDST = value;
-}
-
-void notifyEnabled(ConfigItemBoolean *item, bool value)
-{
-    (void)item;
-    WUPS_StoreBool(nullptr, NOTIFY_ENABLED_CONFIG_ID, value);
-    enabledNotify = value;
-}
-
-void onHourOffsetChanged(ConfigItemIntegerRange *item, int32_t offset)
-{
-    (void)item;
-    WUPS_StoreInt(nullptr, OFFSET_HOURS_CONFIG_ID, offset);
-    offsetHours = offset;
-}
-
-void onMinuteOffsetChanged(ConfigItemIntegerRange *item, int32_t offset)
-{
-    (void)item;
-    WUPS_StoreInt(nullptr, OFFSET_MINUTES_CONFIG_ID, offset);
-    offsetMinutes = offset;
-}
-
-WUPS_GET_CONFIG() {
-    if (WUPS_OpenStorage() != WUPS_STORAGE_ERROR_SUCCESS) {
+    if (WUPS_OpenStorage() != WUPS_STORAGE_ERROR_SUCCESS)
         return 0;
-    }
 
     WUPSConfigHandle settings;
-    WUPSConfig_CreateHandled(&settings, "Wii U Time Sync");
+    WUPSConfig_CreateHandled(&settings, PLUGIN_NAME);
 
     WUPSConfigCategoryHandle config;
     WUPSConfig_AddCategoryByNameHandled(settings, "Configuration", &config);
     WUPSConfigCategoryHandle preview;
     WUPSConfig_AddCategoryByNameHandled(settings, "Preview Time", &preview);
 
-    WUPSConfigItemBoolean_AddToCategoryHandled(settings, config, "enabledSync", "Syncing Enabled", enabledSync, &syncingEnabled);
-    WUPSConfigItemBoolean_AddToCategoryHandled(settings, config, "enabledDST", "Daylight Savings", enabledDST, &savingsEnabled);
-    WUPSConfigItemBoolean_AddToCategoryHandled(settings, config, "enabledNotify", "Receive Notifications", enabledNotify, &notifyEnabled);
-    WUPSConfigItemIntegerRange_AddToCategoryHandled(settings, config, "offsetHours", "Time Offset (hours)", offsetHours, -12, 14, &onHourOffsetChanged);
-    WUPSConfigItemIntegerRange_AddToCategoryHandled(settings, config, "offsetMinutes", "Time Offset (minutes)", offsetMinutes, 0, 59, &onMinuteOffsetChanged);
+    WUPSConfigItemBoolean_AddToCategoryHandled(settings, config, CFG_SYNC,
+                                               "Syncing Enabled",
+                                               cfg::sync,
+                                               [](ConfigItemBoolean*, bool value)
+                                               {
+                                                   WUPS_StoreBool(nullptr, CFG_NOTIFY, value);
+                                                   cfg::notify = value;
+                                               });
+    WUPSConfigItemBoolean_AddToCategoryHandled(settings, config, CFG_NOTIFY,
+                                               "Show Notifications",
+                                               cfg::notify,
+                                               [](ConfigItemBoolean*, bool value)
+                                               {
+                                                   WUPS_StoreBool(nullptr, CFG_NOTIFY, value);
+                                                   cfg::notify = value;
+                                               });
+    WUPSConfigItemIntegerRange_AddToCategoryHandled(settings, config, CFG_MSG_DURATION,
+                                                    "Messages Duration (seconds)",
+                                                    cfg::msg_duration, 0, 30,
+                                                    [](ConfigItemIntegerRange*, int32_t value)
+                                                    {
+                                                        WUPS_StoreInt(nullptr, CFG_MSG_DURATION,
+                                                                      value);
+                                                        cfg::msg_duration = value;
+                                                    });
+    WUPSConfigItemIntegerRange_AddToCategoryHandled(settings, config, CFG_HOURS,
+                                                    "Hours Offset",
+                                                    cfg::hours, -12, 14,
+                                                    [](ConfigItemIntegerRange*, int32_t value)
+                                                    {
+                                                        WUPS_StoreInt(nullptr, CFG_HOURS, value);
+                                                        cfg::hours = value;
+                                                    });
+    WUPSConfigItemIntegerRange_AddToCategoryHandled(settings, config, CFG_MINUTES,
+                                                    "Minutes Offset",
+                                                    cfg::minutes, 0, 59,
+                                                    [](ConfigItemIntegerRange*, int32_t value)
+                                                    {
+                                                        WUPS_StoreInt(nullptr, CFG_MINUTES,
+                                                                      value);
+                                                        cfg::minutes = value;
+                                                    });
+    WUPSConfigItemIntegerRange_AddToCategoryHandled(settings, config, CFG_TOLERANCE,
+                                                    "Tolerance (milliseconds)",
+                                                    cfg::tolerance, 0, 5000,
+                                                    [](ConfigItemIntegerRange*, int32_t value)
+                                                    {
+                                                        WUPS_StoreInt(nullptr, CFG_TOLERANCE,
+                                                                      value);
+                                                        cfg::tolerance = value;
+                                                    });
 
-    OSCalendarTime ct;
-    OSTicksToCalendarTime(OSGetTime(), &ct);
-    char timeString[256];
-    snprintf(timeString, 255, "Current Time: %04d-%02d-%02d %02d:%02d:%02d:%04d:%04d\n", ct.tm_year, ct.tm_mon + 1, ct.tm_mday, ct.tm_hour, ct.tm_min, ct.tm_sec, ct.tm_msec, ct.tm_usec);
-    WUPSConfigItemStub_AddToCategoryHandled(settings, preview, "time", timeString);
+    // show current NTP server address, no way to change it.
+    std::string server = "NTP servers: "s + cfg::server;
+    WUPSConfigItemStub_AddToCategoryHandled(settings, config, CFG_SERVER, server.c_str());
+
+    WUPSConfigItemStub_AddToCategoryHandled(settings, preview, "time",
+                                            format_wiiu_time(OSGetTime()).c_str());
 
     return settings;
 }
 
-WUPS_CONFIG_CLOSED() {
-    if (enabledSync) {
-        std::thread updateTimeThread(updateTime);
-        updateTimeThread.detach(); // Update time when settings are closed.
-    }
-    
+
+WUPS_CONFIG_CLOSED()
+{
+    std::jthread update_time_thread(update_time);
+    update_time_thread.detach(); // Update time when settings are closed.
+
     WUPS_CloseStorage(); // Save all changes.
 }

--- a/source/ntp.hpp
+++ b/source/ntp.hpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef NTP_HPP
+#define NTP_HPP
+
+#include <cstdint>
+
+
+namespace ntp {
+    // For details, see https://www.ntp.org/reflib/rfc/rfc5905.txt
+
+    // This is u32.32 fixed-point format, seconds since 1900-01-01.
+    using timestamp = std::uint64_t;
+
+    // This is a u16.16 fixed-point format.
+    using short_timestamp = std::uint32_t;
+
+
+    // Note: all fields are big-endian
+    struct packet {
+
+        enum class leap : std::uint8_t {
+            no_warning      = 0 << 6,
+            one_more_second = 1 << 6,
+            one_less_second = 2 << 6,
+            unknown         = 3 << 6
+        };
+
+        enum class mode : std::uint8_t {
+            reserved         = 0,
+            active           = 1,
+            passive          = 2,
+            client           = 3,
+            server           = 4,
+            broadcast        = 5,
+            control          = 6,
+            reserved_private = 7
+        };
+
+
+        // Note: all fields are zero-initialized by default constructor.
+        std::uint8_t lvm           = 0; // leap, version and mode
+        std::uint8_t stratum       = 0; // Stratum level of the local clock.
+        std::int8_t  poll_exp      = 0; // Maximum interval between successive messages.
+        std::int8_t  precision_exp = 0; // Precision of the local clock.
+
+        short_timestamp root_delay      = 0; // Total round trip delay time to the reference clock.
+        short_timestamp root_dispersion = 0; // Total dispersion to the reference clock.
+        char            reference_id[4] = {0, 0, 0, 0}; // Reference clock identifier.
+
+        timestamp reference_time = 0; // Reference timestamp.
+        timestamp origin_time    = 0; // Origin timestamp, aka T1.
+        timestamp receive_time   = 0; // Receive timestamp, aka T2.
+        timestamp transmit_time  = 0; // Transmit timestamp, aka T3.
+
+
+        void leap(leap x)
+        {
+            lvm = static_cast<std::uint8_t>(x) | (lvm & 0b0011'1111);
+        }
+
+        void version(unsigned v)
+        {
+            lvm = ((v << 3) & 0b0011'1000) | (lvm & 0b1100'0111);
+        }
+
+        void mode(mode m)
+        {
+            lvm = static_cast<std::uint8_t>(m) | (lvm & 0b1111'1000);
+        }
+
+    };
+
+    static_assert(sizeof(packet) == 48);
+
+} // namespace ntp
+
+
+#endif

--- a/source/wupsxx/base_item.cpp
+++ b/source/wupsxx/base_item.cpp
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+
+#include <cstdio>
+#include <stdexcept>
+
+#include "base_item.hpp"
+
+
+namespace wups {
+
+    base_item::base_item(const std::string& key,
+                         const std::string& name) :
+        key{key},
+        name{name}
+    {
+        WUPSConfigCallbacks_t cb;
+
+        cb.getCurrentValueDisplay = [](void* ctx, char* buf, int size) -> int
+        {
+            if (!ctx)
+                return -1;
+            auto item = reinterpret_cast<const base_item*>(ctx);
+            return item->get_current_value_display(buf, size);
+        };
+
+        cb.getCurrentValueSelectedDisplay = [](void* ctx, char* buf, int size) -> int
+        {
+            if (!ctx)
+                return -1;
+            auto item = reinterpret_cast<const base_item*>(ctx);
+            return item->get_current_value_selected_display(buf, size);
+        };
+
+        cb.onSelected = [](void* ctx, bool is_selected)
+        {
+            if (!ctx)
+                return;
+            auto item = reinterpret_cast<const base_item*>(ctx);
+            item->on_selected(is_selected);
+        };
+
+        cb.restoreDefault = [](void* ctx)
+        {
+            if (!ctx)
+                return;
+            auto item = reinterpret_cast<base_item*>(ctx);
+            item->restore();
+        };
+
+        cb.isMovementAllowed = [](void* ctx) -> bool
+        {
+            if (!ctx)
+                return true;
+            auto item = reinterpret_cast<const base_item*>(ctx);
+            return item->is_movement_allowed();
+        };
+
+        cb.callCallback = [](void* ctx) -> bool
+        {
+            if (!ctx)
+                return false;
+            auto item = reinterpret_cast<base_item*>(ctx);
+            return item->callback();
+        };
+
+        cb.onButtonPressed = [](void* ctx, WUPSConfigButtons button)
+        {
+            if (!ctx)
+                return;
+            auto item = reinterpret_cast<base_item*>(ctx);
+            item->on_button_pressed(button);
+        };
+
+        // Called when WUPS is destroying the object.
+        cb.onDelete = [](void* ctx)
+        {
+            if (!ctx)
+                return;
+            auto item = reinterpret_cast<base_item*>(ctx);
+            item->handle = 0;
+            delete item;
+        };
+
+
+        if (WUPSConfigItem_Create(&handle, key.c_str(), name.c_str(), cb, this) < 0)
+            throw std::runtime_error{"could not create config item"};
+
+    }
+
+
+    base_item::~base_item()
+    {
+        if (handle)
+            WUPSConfigItem_Destroy(handle);
+    }
+
+
+    int
+    base_item::get_current_value_display(char* buf,
+                                         std::size_t size)
+        const
+    {
+        std::snprintf(buf, size, "NOT IMPLEMENTED");
+        return 0;
+    }
+
+
+    int
+    base_item::get_current_value_selected_display(char* buf,
+                                                  std::size_t size)
+        const
+    {
+        return get_current_value_display(buf, size);
+    }
+
+
+    void
+    base_item::on_selected(bool)
+        const
+    {}
+
+
+    void
+    base_item::restore()
+    {}
+
+
+    bool
+    base_item::is_movement_allowed()
+        const
+    {
+        return true;
+    }
+
+
+    bool
+    base_item::callback()
+    {
+        return false;
+    }
+
+
+    void
+    base_item::on_button_pressed(WUPSConfigButtons buttons)
+    {
+        if (buttons & WUPS_CONFIG_BUTTON_X)
+            restore();
+    }
+
+
+} // namespace wups

--- a/source/wupsxx/base_item.cpp
+++ b/source/wupsxx/base_item.cpp
@@ -35,7 +35,7 @@ namespace wups {
         {
             if (!ctx)
                 return;
-            auto item = reinterpret_cast<const base_item*>(ctx);
+            auto item = reinterpret_cast<base_item*>(ctx);
             item->on_selected(is_selected);
         };
 
@@ -116,7 +116,6 @@ namespace wups {
 
     void
     base_item::on_selected(bool)
-        const
     {}
 
 

--- a/source/wupsxx/base_item.hpp
+++ b/source/wupsxx/base_item.hpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef WUPSXX_BASE_ITEM_HPP
+#define WUPSXX_BASE_ITEM_HPP
+
+#include <string>
+
+#include <wups.h>
+
+
+namespace wups {
+
+    struct base_item {
+
+        WUPSConfigItemHandle handle = 0;
+        std::string key;
+        std::string name;
+
+
+        base_item(const std::string& key,
+                  const std::string& name);
+
+        // disallow moving, since the callbacks store the `this` pointer.
+        base_item(base_item&&) = delete;
+
+
+        virtual ~base_item();
+
+
+        virtual int get_current_value_display(char* buf, std::size_t size) const;
+
+        virtual int get_current_value_selected_display(char* buf, std::size_t size) const;
+
+        virtual void on_selected(bool is_selected) const;
+
+        virtual void restore();
+
+        virtual bool is_movement_allowed() const;
+
+        virtual bool callback();
+
+        virtual void on_button_pressed(WUPSConfigButtons buttons);
+
+    };
+
+} // namespace wups
+
+#endif

--- a/source/wupsxx/base_item.hpp
+++ b/source/wupsxx/base_item.hpp
@@ -31,7 +31,7 @@ namespace wups {
 
         virtual int get_current_value_selected_display(char* buf, std::size_t size) const;
 
-        virtual void on_selected(bool is_selected) const;
+        virtual void on_selected(bool is_selected);
 
         virtual void restore();
 

--- a/source/wupsxx/bool_item.cpp
+++ b/source/wupsxx/bool_item.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+
+#include <cstdio>
+#include <stdexcept>
+
+#include "bool_item.hpp"
+#include "storage.hpp"
+
+
+namespace wups {
+
+    bool_item::bool_item(const std::string& key,
+                         const std::string& name,
+                         bool& variable) :
+        base_item{key, name},
+        variable(variable),
+        default_value{variable}
+    {}
+
+
+    int
+    bool_item::get_current_value_display(char* buf, std::size_t size)
+        const
+    {
+        std::snprintf(buf, size, "%s",
+                      variable ? true_str.c_str() : false_str.c_str());
+        return 0;
+    }
+
+
+    int
+    bool_item::get_current_value_selected_display(char* buf, std::size_t size)
+        const
+    {
+        if (variable)
+            std::snprintf(buf, size, "< %s  ", true_str.c_str());
+        else
+            std::snprintf(buf, size, "  %s >", false_str.c_str());
+        return 0;
+    }
+
+
+    void
+    bool_item::restore()
+    {
+        variable = default_value;
+    }
+
+
+    bool
+    bool_item::callback()
+    {
+        if (key.empty())
+            return false;
+
+        try {
+            store(key, variable);
+            return true;
+        }
+        catch (...) {
+            return false;
+        }
+    }
+
+
+    void
+    bool_item::on_button_pressed(WUPSConfigButtons buttons)
+    {
+        base_item::on_button_pressed(buttons);
+
+        if (buttons & WUPS_CONFIG_BUTTON_A)
+            variable = !variable;
+
+        if (buttons & WUPS_CONFIG_BUTTON_LEFT)
+            variable = false;
+
+        if (buttons & WUPS_CONFIG_BUTTON_RIGHT)
+            variable = true;
+    }
+
+} // namespace wups

--- a/source/wupsxx/bool_item.hpp
+++ b/source/wupsxx/bool_item.hpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef WUPSXX_BOOL_ITEM_HPP
+#define WUPSXX_BOOL_ITEM_HPP
+
+#include <string>
+
+#include "base_item.hpp"
+
+namespace wups {
+
+    struct bool_item : base_item {
+
+        bool& variable;
+        bool default_value;
+        std::string true_str = "true";
+        std::string false_str = "false";
+
+
+        bool_item(const std::string& key,
+                  const std::string& name,
+                  bool& variable);
+
+
+        virtual int get_current_value_display(char* buf, std::size_t size) const override;
+
+        virtual int get_current_value_selected_display(char* buf, std::size_t size) const override;
+
+        virtual void restore() override;
+
+        virtual bool callback() override;
+
+        virtual void on_button_pressed(WUPSConfigButtons button) override;
+
+    };
+
+} // namespace wups
+
+#endif

--- a/source/wupsxx/category.cpp
+++ b/source/wupsxx/category.cpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+
+#include <stdexcept>
+
+#include "category.hpp"
+
+
+namespace wups {
+
+    category::category(const std::string& name)
+    {
+        if (WUPSConfigCategory_Create(&handle, name.c_str()) < 0)
+            throw std::runtime_error{"could not create category"};
+    }
+
+
+    category::~category()
+    {
+        if (handle)
+            WUPSConfigCategory_Destroy(handle);
+    }
+
+
+    void
+    category::add(std::unique_ptr<base_item>&& item)
+    {
+        if (!item)
+            throw std::logic_error{"cannot add null item to category"};
+        if (!item->handle)
+            throw std::logic_error{"cannot add null item handle to category"};
+
+        if (WUPSConfigCategory_AddItem(handle, item->handle) < 0)
+            throw std::runtime_error{"cannot add item to category"};
+
+        item.release(); // WUPS now owns this item
+    }
+
+} // namespace wups

--- a/source/wupsxx/category.cpp
+++ b/source/wupsxx/category.cpp
@@ -35,4 +35,18 @@ namespace wups {
         item.release(); // WUPS now owns this item
     }
 
+
+    void
+    category::add(base_item* item)
+    {
+        if (!item)
+            throw std::logic_error{"cannot add null item to category"};
+        if (!item->handle)
+            throw std::logic_error{"cannot add null item handle to category"};
+
+        if (WUPSConfigCategory_AddItem(handle, item->handle) < 0)
+            throw std::runtime_error{"cannot add item to category"};
+    }
+
+
 } // namespace wups

--- a/source/wupsxx/category.hpp
+++ b/source/wupsxx/category.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef WUPSXX_CATEGORY_HPP
+#define WUPSXX_CATEGORY_HPP
+
+#include <memory>
+#include <string>
+
+#include <wups.h>
+
+#include "base_item.hpp"
+
+
+namespace wups {
+
+    struct category {
+
+        WUPSConfigCategoryHandle handle = 0;
+
+        category(const std::string& name);
+
+        category(category&&) = delete;
+
+        ~category();
+
+        void add(std::unique_ptr<base_item>&& item);
+
+    };
+
+} // namespace wups
+
+
+#endif

--- a/source/wupsxx/category.hpp
+++ b/source/wupsxx/category.hpp
@@ -25,6 +25,8 @@ namespace wups {
 
         void add(std::unique_ptr<base_item>&& item);
 
+        void add(base_item* item);
+
     };
 
 } // namespace wups

--- a/source/wupsxx/config.cpp
+++ b/source/wupsxx/config.cpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+
+#include <stdexcept>
+
+#include "config.hpp"
+
+
+namespace wups {
+
+    config::config(const std::string& name)
+    {
+        if (WUPSConfig_Create(&handle, name.c_str()) < 0)
+            throw std::runtime_error{"could not create config"};
+    }
+
+
+    config::~config()
+    {
+        if (handle)
+            WUPSConfig_Destroy(handle);
+    }
+
+
+    void
+    config::add(std::unique_ptr<category>&& cat)
+    {
+        if (!cat)
+            throw std::logic_error{"cannot add null category to config"};
+        if (!cat->handle)
+            throw std::logic_error{"cannot add null category handle to config"};
+
+        if (WUPSConfig_AddCategory(handle, cat->handle) < 0)
+            throw std::runtime_error{"cannot add category to config"};
+
+        cat.release(); // WUPS now owns this category
+    }
+
+} // namespace wups

--- a/source/wupsxx/config.hpp
+++ b/source/wupsxx/config.hpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef WUPSXX_CONFIG_HPP
+#define WUPSXX_CONFIG_HPP
+
+#include <memory>
+#include <string>
+
+#include <wups.h>
+
+#include "category.hpp"
+
+
+namespace wups {
+
+    struct config {
+
+        WUPSConfigHandle handle = 0;
+
+        config(const std::string& name);
+
+        config(config&&) = delete;
+
+        ~config();
+
+        void add(std::unique_ptr<category>&& cat);
+
+    };
+
+} // namespace wups
+
+#endif

--- a/source/wupsxx/int_item.cpp
+++ b/source/wupsxx/int_item.cpp
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+
+#include <algorithm>            // clamp()
+#include <cstdio>
+#include <stdexcept>
+
+#include "int_item.hpp"
+#include "storage.hpp"
+
+
+namespace wups {
+
+
+    int_item::int_item(const std::string& key,
+                       const std::string& name,
+                       int& variable,
+                       int min_value,
+                       int max_value) :
+        base_item{key, name},
+        variable(variable),
+        default_value{variable},
+        min_value{min_value},
+        max_value{max_value}
+    {}
+
+
+    int
+    int_item::get_current_value_display(char* buf, std::size_t size)
+        const
+    {
+        std::snprintf(buf, size, "%d", variable);
+        return 0;
+    }
+
+
+    int
+    int_item::get_current_value_selected_display(char* buf, std::size_t size)
+        const
+    {
+        char left = ' ';
+        char right = ' ';
+        if (variable > min_value)
+            left = '<';
+        if (variable < max_value)
+            right = '>';
+        std::snprintf(buf, size, "%c %d %c", left, variable, right);
+        return 0;
+    }
+
+
+    void
+    int_item::restore()
+    {
+        variable = default_value;
+    }
+
+
+    bool
+    int_item::callback()
+    {
+        if (key.empty())
+            return false;
+
+        try {
+            store(key, variable);
+            return true;
+        }
+        catch (...) {
+            return false;
+        }
+    }
+
+
+    void
+    int_item::on_button_pressed(WUPSConfigButtons buttons)
+    {
+        base_item::on_button_pressed(buttons);
+
+        if (buttons & WUPS_CONFIG_BUTTON_LEFT)
+            --variable;
+
+        if (buttons & WUPS_CONFIG_BUTTON_RIGHT)
+            ++variable;
+
+        if (buttons & WUPS_CONFIG_BUTTON_L)
+            variable -= 50;
+
+        if (buttons & WUPS_CONFIG_BUTTON_R)
+            variable += 50;
+
+        variable = std::clamp(variable, min_value, max_value);
+    }
+
+} // namespace wups

--- a/source/wupsxx/int_item.hpp
+++ b/source/wupsxx/int_item.hpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef WUPSXX_INT_ITEM_HPP
+#define WUPSXX_INT_ITEM_HPP
+
+#include "base_item.hpp"
+
+
+namespace wups {
+
+    struct int_item : base_item {
+
+        int& variable;
+        int default_value = 0;
+        int min_value;
+        int max_value;
+
+
+        int_item(const std::string& key,
+                 const std::string& name,
+                 int& variable,
+                 int min_value,
+                 int max_value);
+
+
+        virtual int get_current_value_display(char* buf, std::size_t size) const override;
+
+        virtual int get_current_value_selected_display(char* buf, std::size_t size) const override;
+
+        virtual void restore() override;
+
+        virtual bool callback() override;
+
+        virtual void on_button_pressed(WUPSConfigButtons buttons) override;
+
+    };
+
+} // namespace wups
+
+#endif

--- a/source/wupsxx/storage.cpp
+++ b/source/wupsxx/storage.cpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+
+#include <wups.h>
+
+#include "storage.hpp"
+
+
+namespace wups {
+
+    template<>
+    std::expected<bool, WUPSStorageError>
+    load<bool>(const std::string& key)
+    {
+        bool value;
+        auto err = WUPS_GetBool(nullptr, key.c_str(), &value);
+        if (err != WUPS_STORAGE_ERROR_SUCCESS)
+            return std::unexpected{err};
+        return value;
+    }
+
+
+    template<>
+    std::expected<int, WUPSStorageError>
+    load<int>(const std::string& key)
+    {
+        int value;
+        auto err = WUPS_GetInt(nullptr, key.c_str(), &value);
+        if (err != WUPS_STORAGE_ERROR_SUCCESS)
+            return std::unexpected{err};
+        return value;
+    }
+
+
+    template<>
+    std::expected<std::string, WUPSStorageError>
+    load<std::string>(const std::string& key)
+    {
+        // Note: we don't have WUPS_GetSize() so we can't know how big this has to be.
+        std::string value(1024, '\0');
+        auto err = WUPS_GetString(nullptr, key.c_str(), value.data(), value.size());
+        if (err != WUPS_STORAGE_ERROR_SUCCESS)
+            return std::unexpected{err};
+        auto end = value.find('\0');
+        return value.substr(0, end);
+    }
+
+
+    template<>
+    void
+    store<bool>(const std::string& key,
+                const bool& value)
+    {
+        auto err = WUPS_StoreBool(nullptr, key.c_str(), value);
+        if (err != WUPS_STORAGE_ERROR_SUCCESS)
+            throw err;
+    }
+
+
+    template<>
+    void
+    store<int>(const std::string& key,
+               const int& value)
+    {
+        auto err = WUPS_StoreInt(nullptr, key.c_str(), value);
+        if (err != WUPS_STORAGE_ERROR_SUCCESS)
+            throw err;
+    }
+
+
+    template<>
+    void
+    store<std::string>(const std::string& key,
+                       const std::string& value)
+    {
+        auto err = WUPS_StoreString(nullptr, key.c_str(), value.c_str());
+        if (err != WUPS_STORAGE_ERROR_SUCCESS)
+            throw err;
+    }
+
+} // namespace wups

--- a/source/wupsxx/storage.hpp
+++ b/source/wupsxx/storage.hpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef WUPSXX_STORAGE_HPP
+#define WUPSXX_STORAGE_HPP
+
+#include <string>
+#include <expected>
+
+
+namespace wups {
+
+    template<typename T>
+    std::expected<T, WUPSStorageError>
+    load(const std::string& key);
+
+    template<typename T>
+    void store(const std::string& key, const T& value);
+
+} // namespace wups
+
+#endif

--- a/source/wupsxx/text_item.cpp
+++ b/source/wupsxx/text_item.cpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+#include <cstdio>
+#include <stdexcept>
+
+#include "text_item.hpp"
+
+
+using namespace std::literals;
+
+namespace wups {
+
+    text_item::text_item(const std::string& key,
+                         const std::string& name,
+                         const std::string& text) :
+        base_item{key, name},
+        text{text}
+    {}
+
+
+    int
+    text_item::get_current_value_display(char* buf,
+                                         std::size_t size)
+        const
+    {
+        std::snprintf(buf, size, text.c_str());
+        if (size > 3 && text.size() + 1 > size)
+            // replace last 3 chars of buf with "..."
+            buf[size - 2] = buf[size - 3] = buf[size - 4] = '.';
+        return 0;
+    }
+
+} // namespace wups

--- a/source/wupsxx/text_item.cpp
+++ b/source/wupsxx/text_item.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 
+#include <algorithm>
 #include <cstdio>
 #include <stdexcept>
 
@@ -23,11 +24,47 @@ namespace wups {
                                          std::size_t size)
         const
     {
-        std::snprintf(buf, size, text.c_str());
-        if (size > 3 && text.size() + 1 > size)
-            // replace last 3 chars of buf with "..."
-            buf[size - 2] = buf[size - 3] = buf[size - 4] = '.';
+        auto width = std::min<int>(size - 1, max_width);
+
+        std::snprintf(buf, size,
+                      "%*.*s",
+                      width,
+                      width,
+                      text.c_str() + start);
+
         return 0;
+    }
+
+
+    void
+    text_item::on_selected(bool is_selected)
+    {
+        if (!is_selected)
+            start = 0;
+    }
+
+
+    void
+    text_item::on_button_pressed(WUPSConfigButtons buttons)
+    {
+        if (text.empty())
+            return;
+
+        int tsize = static_cast<int>(text.size());
+
+        if (tsize <= max_width)
+            return;
+
+        if (buttons & WUPS_CONFIG_BUTTON_LEFT)
+            start -= 5;
+
+        if (buttons & WUPS_CONFIG_BUTTON_RIGHT)
+            start += 5;
+
+        if (start >= tsize - max_width)
+            start = tsize - max_width;
+        if (start < 0)
+            start = 0;
     }
 
 } // namespace wups

--- a/source/wupsxx/text_item.hpp
+++ b/source/wupsxx/text_item.hpp
@@ -10,6 +10,8 @@ namespace wups {
     struct text_item : base_item {
 
         std::string text;
+        int max_width = 50;
+        int start = 0;
 
         text_item(const std::string& key = "",
                   const std::string& name = "",
@@ -17,6 +19,9 @@ namespace wups {
 
         virtual int get_current_value_display(char* buf, std::size_t size) const override;
 
+        virtual void on_selected(bool is_selected) override;
+
+        virtual void on_button_pressed(WUPSConfigButtons buttons) override;
     };
 
 } // namespace wups

--- a/source/wupsxx/text_item.hpp
+++ b/source/wupsxx/text_item.hpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+#ifndef WUPSXX_TEXT_ITEM_HPP
+#define WUPSXX_TEXT_ITEM_HPP
+
+#include "base_item.hpp"
+
+namespace wups {
+
+    struct text_item : base_item {
+
+        std::string text;
+
+        text_item(const std::string& key = "",
+                  const std::string& name = "",
+                  const std::string& text = "");
+
+        virtual int get_current_value_display(char* buf, std::size_t size) const override;
+
+    };
+
+} // namespace wups
+
+
+#endif


### PR DESCRIPTION
I tried to improve the Preview function. Now, by pressing "A" it will query (sequentially) all the NTP servers, and add text entries with the correction for each IP address (or error status like timeout). Then the current local clock is shown, with the calculated correction.
![preview-pic](https://github.com/Nightkingale/Wii-U-Time-Sync/assets/9806337/fc1b1fa8-3e0f-4759-b3ed-2b795b9e0cc3)
Sadly, due to WUPS limitations, it doesn't work perfectly. The new entries are not shown until the user either tries to scroll the screen ("DOWN" then "UP"), or exit then reenter the Preview. After they new entries are shown by WUPS, they seem to update correctly when pressing "A".
And since I had to implement a "text item" element from scratch, I also decided to re-implement the "bool" and "int" items. By pressing "X" (actually "Y" because WUPS swaps the "X" and "Y" buttons for some reason) my own items can also restore the value that was loaded from the config file. Besides the extra functionality, from the code perspective, they're much more convenient to use, automatically updating the config file when changing value, and require no explicit error handling (everything is exception-safe.)