### PR TITLE
Added convenience script to init and update submodules.

### DIFF
--- a/external/update-submodules.sh
+++ b/external/update-submodules.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+GREEN=$(tput setaf 10)
+YELLOW=$(tput setaf 11)
+NONE=$(tput sgr0)
+
+
+update_submodule()
+{
+    echo "${GREEN}${1}${NONE}: '${YELLOW}git -C $1 submodule init${NONE}'"
+    git -C $1 submodule init || exit 1
+    echo "${GREEN}${1}${NONE}: '${YELLOW}git -C $1 submodule update --recursive${NONE}'"
+    git -C $1 submodule update --recursive || exit 2
+}
+
+
+update_submodule libcurlwrapper
+update_submodule libwupsxx
+
+exit 0


### PR DESCRIPTION
Script to help ensuring all git submodules are initialized and updated.

Particularly useful when the initial `git clone` command didn't have `--recurse-submodules`.